### PR TITLE
Allow Custom Limiting in API

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -11,7 +11,7 @@ var uuid = require('node-uuid')
 module.exports = function(app) {
   // JSON API
   app.get('/api/stats/:id', statsShow);
-  app.get('/api/matches', matches);
+  app.get('/api/matches/:limit', matches);
   app.get('/api/player/:id', player);
   app.get('/api/player/:id/matches', playerMatches);
   app.get('/api/playersearch', playerSearch);
@@ -74,9 +74,13 @@ var statsShow = function(req, res) {
 };
 
 var matches = function(req, res) {
+	var limitCount = req.params.limit;
+	if (limitCount == 0) {
+		limitCount = 12; //Default Value if one is not specified
+	}
   Stats.find({})
   .sort({_id:-1})
-  .limit(12)
+  .limit(limitCount)
   .select('hostname redname bluname redCountry bluCountry isLive')
   .lean()
   .exec(function(err, matches) {

--- a/routes/api.js
+++ b/routes/api.js
@@ -75,7 +75,7 @@ var statsShow = function(req, res) {
 
 var matches = function(req, res) {
   var limitCount = req.params.limit;
-  if (limitCount < 1 || limitCount == null || ) {
+  if (limitCount < 1 || limitCount == null) {
     limitCount = 12; //Default Value if one is not specified
   }
   Stats.find({})

--- a/routes/api.js
+++ b/routes/api.js
@@ -74,10 +74,10 @@ var statsShow = function(req, res) {
 };
 
 var matches = function(req, res) {
-	var limitCount = req.params.limit;
-	if (limitCount == 0) {
-		limitCount = 12; //Default Value if one is not specified
-	}
+  var limitCount = req.params.limit;
+  if (limitCount == 0) {
+    limitCount = 12; //Default Value if one is not specified
+  }
   Stats.find({})
   .sort({_id:-1})
   .limit(limitCount)

--- a/routes/api.js
+++ b/routes/api.js
@@ -75,7 +75,7 @@ var statsShow = function(req, res) {
 
 var matches = function(req, res) {
   var limitCount = req.params.limit;
-  if (limitCount == 0) {
+  if (limitCount < 1 || limitCount == null || ) {
     limitCount = 12; //Default Value if one is not specified
   }
   Stats.find({})


### PR DESCRIPTION
I was speaking with SizzlingCalamari about some things and this was one thing I suggested that he encouraged me to work with and do a pull request. I went ahead and allowed for a modifiable limiting factor when someone calls /api/matches. The user can choose /api/matches/3 if they only wanted the JSON to return 3 matches instead of the default 12. However if no matches are defined it should return with the default 12 matches. If something is wrong feel free to let me know.